### PR TITLE
Refactor block hash handling to use SHA-256 strings

### DIFF
--- a/examples/online_serving/kv_events_subscriber.py
+++ b/examples/online_serving/kv_events_subscriber.py
@@ -22,15 +22,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[str]
-    parent_block_hash: Optional[str]
+    block_hashes: list[bytes]
+    parent_block_hash: Optional[bytes]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[str]
+    block_hashes: list[bytes]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/examples/online_serving/kv_events_subscriber.py
+++ b/examples/online_serving/kv_events_subscriber.py
@@ -22,15 +22,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[int]
-    parent_block_hash: Optional[int]
+    block_hashes: list[str]
+    parent_block_hash: Optional[str]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[int]
+    block_hashes: list[str]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,8 +3,8 @@
 import importlib
 from typing import Optional
 
-import hashlib
 import cbor2
+import hashlib
 import pytest
 import torch
 
@@ -94,16 +94,16 @@ def test_none_hash(monkeypatch):
         reloaded = importlib.reload(vllm.v1.core.kv_cache_utils)
         reloaded.init_none_hash()
         assert reloaded.NONE_HASH is not None
-        assert isinstance(reloaded.NONE_HASH, str)
-        assert reloaded.NONE_HASH != ""
+        assert isinstance(reloaded.NONE_HASH, bytes)
+        assert reloaded.NONE_HASH != b""
 
     # case 2: PYTHONHASHSEED is set, use the seed
     with monkeypatch.context() as m:
         m.setenv('PYTHONHASHSEED', 'python hash seed')
         reloaded = importlib.reload(vllm.v1.core.kv_cache_utils)
         reloaded.init_none_hash()
-        expected = hashlib.sha256(b'python hash seed').hexdigest()
-        assert isinstance(reloaded.NONE_HASH, str)
+        expected = hashlib.sha256(b'python hash seed').digest()
+        assert isinstance(reloaded.NONE_HASH, bytes)
         assert reloaded.NONE_HASH == expected
 
 
@@ -123,7 +123,7 @@ def test_kv_cache_block():
     assert block.ref_cnt == 0
 
     # Test block hash setting and resetting
-    block_hash = "abc:0"
+    block_hash = b"abc:0"
     block.block_hash = block_hash
     assert block.block_hash == block_hash
 
@@ -404,7 +404,7 @@ def test_generate_block_hash_extra_keys_cache_salt():
 
 def test_hash_block_tokens():
     init_none_hash()
-    parent_block_hash = "123"
+    parent_block_hash = b"123"
     curr_block_token_ids = (1, 2, 3)
     extra_keys = ("key1", "key2")
 
@@ -412,7 +412,7 @@ def test_hash_block_tokens():
                                    extra_keys)
     expected = hashlib.sha256(
         cbor2.dumps((parent_block_hash, curr_block_token_ids, extra_keys),
-                    canonical=True)).hexdigest()
+                    canonical=True)).digest()
     assert block_hash == expected
 
 
@@ -431,6 +431,7 @@ def test_request_block_hasher():
 
     block_hashes = request.block_hashes
     assert len(block_hashes) == 2
+    assert isinstance(block_hashes[0], bytes)
 
 
 def test_hash_tokens_different_mm_input():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3,7 +3,7 @@
 """Compare the with and without prefix caching."""
 
 import copy
-from typing import Callable, Optional
+from typing import Optional
 
 import pytest
 import torch
@@ -11,11 +11,9 @@ import torch
 from vllm.distributed.kv_events import AllBlocksCleared, BlockRemoved
 from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
 from vllm.sampling_params import SamplingParams
-from vllm.utils import sha256, sha256_cbor_64bit
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
-from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
-                                         KVCacheBlock,
+from vllm.v1.core.kv_cache_utils import (KVCacheBlock,
                                          get_request_block_hasher,
                                          hash_block_tokens, init_none_hash)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -26,7 +24,6 @@ def make_request(
     request_id: str,
     prompt_token_ids: list[int],
     block_size: int,
-    hash_fn: Callable,
     mm_positions: Optional[list[PlaceholderRange]] = None,
     mm_hashes: Optional[list[str]] = None,
     prompt_logprobs: Optional[int] = None,
@@ -49,7 +46,7 @@ def make_request(
                    eos_token_id=100,
                    lora_request=None,
                    cache_salt=cache_salt,
-                   block_hasher=get_request_block_hasher(block_size, hash_fn))
+                   block_hasher=get_request_block_hasher(block_size))
 
 
 def make_kv_cache_config(block_size: int, num_blocks: int) -> KVCacheConfig:
@@ -97,18 +94,13 @@ def make_kv_cache_config_hybrid_model(block_size: int,
     )
 
 
-@pytest.mark.parametrize("hash_algo", ["sha256", "sha256_cbor_64bit", "hash"])
-def test_prefill(hash_algo):
+def test_prefill():
     block_size = 16
     manager = KVCacheManager(
         make_kv_cache_config(block_size, 11),
         max_model_len=8192,
         enable_caching=True,
     )
-
-    # choose the hash function according to the parameter
-    hash_fn = (sha256_cbor_64bit if hash_algo == "sha256_cbor_64bit" else
-               sha256 if hash_algo == "sha256" else hash)
 
     # Complete 3 blocks (48 tokens)
     common_token_ids = [i for i in range(3) for _ in range(16)]
@@ -117,7 +109,7 @@ def test_prefill(hash_algo):
     # Incomplete 1 block (7 tokens)
     unique_token_ids = [3] * 7
     all_token_ids = common_token_ids + unique_token_ids
-    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    req0 = make_request("0", all_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert len(req0.block_hashes) == 3
     assert not computed_blocks.blocks[0]
@@ -131,12 +123,10 @@ def test_prefill(hash_algo):
     parent_block_hash = None
     for block_id in (1, 2, 3):
         block_tokens = tuple(all_token_ids[(block_id - 1) * 16:block_id * 16])
-        block_hash = hash_block_tokens(hash_fn, parent_block_hash,
-                                       block_tokens)
-        assert manager.block_pool.blocks[
-            block_id].block_hash.block_hash == block_hash
+        block_hash = hash_block_tokens(parent_block_hash, block_tokens)
+        assert manager.block_pool.blocks[block_id].block_hash.split(":")[0] == block_hash
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
-        parent_block_hash = block_hash.hash_value
+        parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, ):
@@ -146,8 +136,7 @@ def test_prefill(hash_algo):
     # Cache hit in the common prefix when the original block is still in use.
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
-    req1 = make_request("1", common_token_ids + unique_token_ids, block_size,
-                        hash_fn)
+    req1 = make_request("1", common_token_ids + unique_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert len(req1.block_hashes) == 3
     assert computed_blocks.get_block_ids() == ([1, 2, 3], )
@@ -182,8 +171,7 @@ def test_prefill(hash_algo):
     # Cache hit in the common prefix when the original block is already free.
     # Incomplete 1 block (6 tokens)
     unique_token_ids = [3] * 6
-    req2 = make_request("2", common_token_ids + unique_token_ids, block_size,
-                        hash_fn)
+    req2 = make_request("2", common_token_ids + unique_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert len(req2.block_hashes) == 3
     assert computed_blocks.get_block_ids() == ([1, 2, 3], )
@@ -204,7 +192,7 @@ def test_prefill(hash_algo):
     manager.free(req2)
 
     # Cache miss and eviction.
-    req3 = make_request("3", [99] * (16 * 10), block_size, hash_fn)
+    req3 = make_request("3", [99] * (16 * 10), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -229,8 +217,6 @@ def test_prefill_hybrid_model():
         enable_caching=True,
     )
 
-    hash_fn = hash
-
     # Complete 3 blocks (48 tokens)
     common_token_ids = [i for i in range(3) for _ in range(block_size)]
 
@@ -238,7 +224,7 @@ def test_prefill_hybrid_model():
     # Incomplete 1 block (7 tokens)
     unique_token_ids = [3] * 7
     all_token_ids = common_token_ids + unique_token_ids
-    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    req0 = make_request("0", all_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert len(req0.block_hashes) == 3
     assert not computed_blocks.blocks[0]
@@ -254,13 +240,12 @@ def test_prefill_hybrid_model():
     for length, block_ids in zip((1, 2, 3),
                                  ((1, 5, 9), (2, 6, 10), (3, 7, 11))):
         block_tokens = tuple(all_token_ids[(length - 1) * 16:length * 16])
-        block_hash = hash_block_tokens(hash_fn, parent_block_hash,
-                                       block_tokens)
+        block_hash = hash_block_tokens(parent_block_hash, block_tokens)
         for block_id in block_ids:
-            assert manager.block_pool.blocks[
-                block_id].block_hash.block_hash == block_hash
+            assert (manager.block_pool.blocks[block_id].block_hash.split(":")[0]
+                    == block_hash)
             assert manager.block_pool.blocks[block_id].ref_cnt == 1
-        parent_block_hash = block_hash.hash_value
+        parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, 8, 12):
@@ -270,8 +255,7 @@ def test_prefill_hybrid_model():
     # Cache hit in the common prefix
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
-    req1 = make_request("1", common_token_ids + unique_token_ids, block_size,
-                        hash_fn)
+    req1 = make_request("1", common_token_ids + unique_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert len(req1.block_hashes) == 3
     assert computed_blocks.get_block_ids() == ([1, 2, 3], [0, 6,
@@ -295,10 +279,10 @@ def test_prefill_hybrid_model():
         manager.block_pool.cached_block_hash_to_block)
 
     def test_partial_request_hit(request_id: str,
-                                 hash_to_evict: list[BlockHashWithGroupId],
+                                 hash_to_evict: list[str],
                                  expect_hit_length: int):
         req = make_request(request_id, common_token_ids + unique_token_ids,
-                           block_size, hash)
+                           block_size)
         for hash_with_group_id in hash_to_evict:
             manager.block_pool.cached_block_hash_to_block.pop(
                 hash_with_group_id)
@@ -315,32 +299,32 @@ def test_prefill_hybrid_model():
 
     # Evict the blocks outside sliding window, does not affect the hit length.
     test_partial_request_hit("2", [
-        BlockHashWithGroupId(block_hashes[0], 1),
-        BlockHashWithGroupId(block_hashes[0], 2)
+        f"{block_hashes[0]}:1",
+        f"{block_hashes[0]}:2"
     ], 3)
 
     # Evict the first block of full attention, makes total cache miss.
     test_partial_request_hit("3", [
-        BlockHashWithGroupId(block_hashes[0], 0),
+        f"{block_hashes[0]}:0",
     ], 0)
 
     # Evict the last block of all layers, reduces the hit length to 2.
     test_partial_request_hit("4", [
-        BlockHashWithGroupId(block_hashes[2], 0),
-        BlockHashWithGroupId(block_hashes[2], 1),
-        BlockHashWithGroupId(block_hashes[2], 2),
+        f"{block_hashes[2]}:0",
+        f"{block_hashes[2]}:1",
+        f"{block_hashes[2]}:2",
     ], 2)
 
     # Evict the last block of full attention, reduces the hit length to 2.
-    test_partial_request_hit("5", [BlockHashWithGroupId(block_hashes[2], 0)],
+    test_partial_request_hit("5", [f"{block_hashes[2]}:0"],
                              2)
 
     # Evict the last block of sliding window, reduces the hit length to 2.
-    test_partial_request_hit("6", [BlockHashWithGroupId(block_hashes[2], 1)],
+    test_partial_request_hit("6", [f"{block_hashes[2]}:1"],
                              2)
 
     # Evict the last block of sliding window, reduces the hit length to 2.
-    test_partial_request_hit("7", [BlockHashWithGroupId(block_hashes[2], 2)],
+    test_partial_request_hit("7", [f"{block_hashes[2]}:2"],
                              2)
 
     # Evict different set of blocks for full attention and sliding window makes
@@ -349,9 +333,9 @@ def test_prefill_hybrid_model():
     # The cache hit length of sliding window is 2 * block_size.
     # Then it is cache miss as the two type of layers have different hit length.
     test_partial_request_hit("8", [
-        BlockHashWithGroupId(block_hashes[2], 0),
-        BlockHashWithGroupId(block_hashes[0], 1),
-        BlockHashWithGroupId(block_hashes[0], 2),
+        f"{block_hashes[2]}:0",
+        f"{block_hashes[0]}:1",
+        f"{block_hashes[0]}:2",
     ], 0)
 
 
@@ -368,9 +352,6 @@ def test_prefill_plp():
         max_model_len=8192,
         enable_caching=True,
     )
-    # the default hash function is hash
-    hash_fn = hash
-
     # Complete 3 blocks (48 tokens)
     common_token_ids = [i for i in range(3) for _ in range(16)]
 
@@ -382,7 +363,6 @@ def test_prefill_plp():
     req0 = make_request("0",
                         all_token_ids,
                         block_size,
-                        hash_fn,
                         prompt_logprobs=5)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert len(req0.block_hashes) == 3
@@ -398,12 +378,11 @@ def test_prefill_plp():
     parent_block_hash = None
     for block_id in (1, 2, 3):
         block_tokens = tuple(all_token_ids[(block_id - 1) * 16:block_id * 16])
-        block_hash = hash_block_tokens(hash_fn, parent_block_hash,
-                                       block_tokens)
-        assert manager.block_pool.blocks[
-            block_id].block_hash.block_hash == block_hash
+        block_hash = hash_block_tokens(parent_block_hash, block_tokens)
+        assert (manager.block_pool.blocks[block_id].block_hash.split(":")[0]
+                == block_hash)
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
-        parent_block_hash = block_hash.hash_value
+        parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, ):
@@ -414,8 +393,7 @@ def test_prefill_plp():
     # Cache hit in the common prefix when the original block is still in use.
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
-    req1 = make_request("1", common_token_ids + unique_token_ids, block_size,
-                        hash_fn)
+    req1 = make_request("1", common_token_ids + unique_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert len(req1.block_hashes) == 3
     assert computed_blocks.get_block_ids() == ([1, 2, 3], )
@@ -452,7 +430,6 @@ def test_prefill_plp():
     req2 = make_request("2",
                         common_token_ids + unique_token_ids,
                         block_size,
-                        hash_fn,
                         prompt_logprobs=5)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert len(req2.block_hashes) == 3
@@ -488,8 +465,7 @@ def test_decode():
     # Fully cache miss
     # Incomplete 1 block (7 tokens)
     unique_token_ids = [3] * 7
-    req0 = make_request("0", common_token_ids + unique_token_ids, block_size,
-                        hash)
+    req0 = make_request("0", common_token_ids + unique_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -534,7 +510,7 @@ def test_evict():
     )
 
     last_token_id = 5 * 16 + 7
-    req0 = make_request("0", list(range(last_token_id)), block_size, hash)
+    req0 = make_request("0", list(range(last_token_id)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -545,8 +521,7 @@ def test_evict():
 
     # 3 blocks.
     req1 = make_request("1", list(range(last_token_id,
-                                        last_token_id + 3 * 16)), block_size,
-                        hash)
+                                        last_token_id + 3 * 16)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -568,7 +543,7 @@ def test_evict():
     ] == [10, 6, 5, 4, 3, 2, 1, 9, 8, 7]
 
     # Touch the first 2 blocks.
-    req2 = make_request("2", list(range(2 * 16 + 3)), block_size, hash)
+    req2 = make_request("2", list(range(2 * 16 + 3)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert computed_blocks.get_block_ids() == ([1, 2], )
     assert num_computed_tokens == 2 * 16
@@ -593,7 +568,7 @@ def test_hash_block_correct_reuse():
 
     # Allocate 1 block and cache it.
     num_tokens = block_size * 1
-    req = make_request("0", list(range(num_tokens)), block_size, hash)
+    req = make_request("0", list(range(num_tokens)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -607,7 +582,7 @@ def test_hash_block_correct_reuse():
 
     # Allocate a new block that's not full, make sure hash info on the
     # block is cleared.
-    req = make_request("1", list(range(num_tokens - 1)), block_size, hash)
+    req = make_request("1", list(range(num_tokens - 1)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -634,7 +609,7 @@ def test_computed_blocks_not_evicted():
 
     # Allocate a block and cache it.
     num_tokens = block_size * 1
-    req0 = make_request("0", list(range(num_tokens)), block_size, hash)
+    req0 = make_request("0", list(range(num_tokens)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -646,7 +621,7 @@ def test_computed_blocks_not_evicted():
 
     # Allocate another block.
     req1 = make_request("1", list(range(num_tokens, num_tokens * 2)),
-                        block_size, hash)
+                        block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -662,7 +637,7 @@ def test_computed_blocks_not_evicted():
 
     # Now if we have a cache hit on the first block, we should evict the second
     # cached block rather than the first one.
-    req2 = make_request("2", list(range(num_tokens * 2)), block_size, hash)
+    req2 = make_request("2", list(range(num_tokens * 2)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert len(computed_blocks.blocks[0]) == 1
     assert computed_blocks.blocks[0][0].block_id == 1
@@ -686,8 +661,7 @@ def test_basic_prefix_caching_disabled():
         enable_caching=False,
     )
 
-    req1 = make_request("1", list(range(10)), block_size,
-                        hash)  # 2 blocks and some more
+    req1 = make_request("1", list(range(10)), block_size)  # 2 blocks and some more
 
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert not computed_blocks.blocks[0]
@@ -701,8 +675,7 @@ def test_basic_prefix_caching_disabled():
     manager.free(req1)
 
     # No caching.
-    req2 = make_request("2", list(range(16)), block_size,
-                        hash)  # shared prefix
+    req2 = make_request("2", list(range(16)), block_size)  # shared prefix
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -712,7 +685,7 @@ def test_basic_prefix_caching_disabled():
     assert len(blocks.blocks[0]) == 4
 
     # New requests should not have any blocks.
-    req3 = make_request("3", list(range(4)), block_size, hash)
+    req3 = make_request("3", list(range(4)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -722,13 +695,12 @@ def test_basic_prefix_caching_disabled():
     assert not blocks
 
 
-@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor_64bit, hash])
-def test_cache_blocks(hash_fn):
+def test_cache_blocks():
     """
     This is a unit test that tests the correctness of the _cache_full_blocks
     function of KVCacheManager.
     """
-    init_none_hash(hash_fn)
+    init_none_hash()
 
     block_size = 4
     block_pool = BlockPool(
@@ -740,7 +712,7 @@ def test_cache_blocks(hash_fn):
     #  Block 1: [4, 5, 6, 7]
     #  Block 2: [8, 9, 10, 11]
     #  Block 3: [12, 13]
-    req = make_request("0", list(range(14)), block_size, hash_fn)
+    req = make_request("0", list(range(14)), block_size)
 
     # Test that blocks are cached correctly for 2 full blocks from the start.
     blocks = [KVCacheBlock(block_id=i) for i in range(2)]
@@ -783,7 +755,7 @@ def test_cache_blocks_multi_group():
     #  Block 1/5: [4, 5, 6, 7]
     #  Block 2/6: [8, 9, 10, 11]
     #  Block 3/7: [12, 13]
-    req = make_request("0", list(range(14)), block_size, hash)
+    req = make_request("0", list(range(14)), block_size)
 
     # Cache the blocks for group 0.
     blocks = [KVCacheBlock(block_id=i) for i in range(2)]
@@ -870,7 +842,6 @@ def test_mm_prefix_caching():
     req0 = make_request("0",
                         all_token_ids,
                         block_size,
-                        hash,
                         mm_positions=mm_positions,
                         mm_hashes=mm_hashes)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
@@ -880,9 +851,6 @@ def test_mm_prefix_caching():
     assert num_computed_tokens == 0
     block_hashes = req0.block_hashes
     assert len(block_hashes) == 3
-    assert block_hashes[0].extra_keys == ("aaa", )
-    assert block_hashes[1].extra_keys == ("aaa", "bbb")
-    assert block_hashes[2].extra_keys == ("bbb", )
 
     blocks = manager.allocate_slots(req0, 59,
                                     len(computed_blocks.blocks[0]) * 16,
@@ -900,7 +868,6 @@ def test_mm_prefix_caching():
 
     # The just completed block should have hashes with extra keys.
     assert len(block_hashes) == 4
-    assert block_hashes[3].extra_keys == ("ccc", )
 
     # Cache hit.
     unique_token_ids = [-1] * 7 + [200] * 5
@@ -912,7 +879,6 @@ def test_mm_prefix_caching():
     req1 = make_request("1",
                         all_token_ids,
                         block_size,
-                        hash,
                         mm_positions=mm_positions,
                         mm_hashes=mm_hashes)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
@@ -935,7 +901,7 @@ def test_cache_key_salting():
     # 3 complete blocks and an incomplete block with 11 tokens.
     common_token_ids = [i for i in range(3) for _ in range(block_size)]
     token_ids = common_token_ids + [3] * 11
-    req0 = make_request("0", token_ids, block_size, hash, cache_salt="salt1")
+    req0 = make_request("0", token_ids, block_size, cache_salt="salt1")
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
 
     # Completed block should have hashes with extra keys.
@@ -943,9 +909,6 @@ def test_cache_key_salting():
     assert num_computed_tokens == 0
     block_hashes = req0.block_hashes
     assert len(block_hashes) == 3
-    assert block_hashes[0].extra_keys == ("salt1", )
-    assert block_hashes[1].extra_keys is None
-    assert block_hashes[2].extra_keys is None
 
     blocks = manager.allocate_slots(req0, 59,
                                     len(computed_blocks.blocks[0]) * 16,
@@ -963,11 +926,10 @@ def test_cache_key_salting():
 
     # Now one more block that should not have extra keys.
     assert len(block_hashes) == 4
-    assert block_hashes[3].extra_keys is None
 
     # Test cache hit with a new request that has the same salt.
     token_ids = common_token_ids + [4] * 11
-    req1 = make_request("1", token_ids, block_size, hash, cache_salt="salt1")
+    req1 = make_request("1", token_ids, block_size, cache_salt="salt1")
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     # Should match only a prefix of 3 blocks.
     assert len(computed_blocks.blocks[0]) == 3
@@ -975,13 +937,12 @@ def test_cache_key_salting():
 
     # Test cache miss with same content but different salt.
     token_ids = common_token_ids + [4] * 11
-    req2 = make_request("2", token_ids, block_size, hash, cache_salt="salt2")
+    req2 = make_request("2", token_ids, block_size, cache_salt="salt2")
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert len(computed_blocks.blocks[0]) == 0
     assert num_computed_tokens == 0
     block_hashes = req2.block_hashes
     assert len(block_hashes) == 3
-    assert block_hashes[0].extra_keys == ("salt2", )
 
 
 def test_prefill_not_enough_free_blocks_with_computed_blocks():
@@ -1000,7 +961,7 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     # Complete 3 blocks (48 tokens)
     # | Common-0 | Common-1 | Common-2 | ... |
     common_token_ids = [i for i in range(3) for _ in range(16)]
-    req0 = make_request("0", common_token_ids, block_size, hash)
+    req0 = make_request("0", common_token_ids, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -1011,7 +972,7 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
         req0.request_id]
 
     # | Common-0 | Common-1 | Common-2 | Req1-3 | Req1-4 | Req1-5 | ... |
-    req1 = make_request("1", common_token_ids * 2, block_size, hash)
+    req1 = make_request("1", common_token_ids * 2, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert computed_blocks.blocks[0] == block_part0
     assert num_computed_tokens == 3 * 16
@@ -1028,7 +989,7 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
 
     # | Common-0 | Common-1 | Common-2 | Req1-3 (F) | Req1-4 (F) |
     # | Req1-5(F)| Req2-0   | Req2-1   | ... |
-    req2 = make_request("2", [7] * block_size * 2, block_size, hash)
+    req2 = make_request("2", [7] * block_size * 2, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -1040,7 +1001,7 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     # but it cannot be allocated due to insufficient free blocks (2).
     # In this case, the ref_cnt of the computed blocks should not be changed.
     assert manager.block_pool.free_block_queue.num_free_blocks == 5
-    req3 = make_request("3", common_token_ids * 3, block_size, hash)
+    req3 = make_request("3", common_token_ids * 3, block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
     assert computed_blocks.blocks[0] == block_part1
     assert num_computed_tokens == 6 * 16
@@ -1065,13 +1026,13 @@ def test_reset_prefix_cache():
     full_block_token_ids = [i for i in range(3) for _ in range(16)]
     unique_token_ids = [3] * 7
     all_token_ids = full_block_token_ids + unique_token_ids
-    req0 = make_request("0", all_token_ids, block_size, hash)
+    req0 = make_request("0", all_token_ids, block_size)
     blocks = manager.allocate_slots(req0, 55)
     assert blocks.get_block_ids() == ([1, 2, 3, 4], )
 
     unique_token_ids = [4] * 7
     all_token_ids = full_block_token_ids + unique_token_ids
-    req1 = make_request("1", all_token_ids, block_size, hash)
+    req1 = make_request("1", all_token_ids, block_size)
     computed_blocks, _ = manager.get_computed_blocks(req1)
     assert len(req1.block_hashes) == 3
     assert len(computed_blocks.blocks[0]) == 3
@@ -1105,7 +1066,7 @@ def test_prefix_cache_stats_disabled():
     assert manager.prefix_cache_stats is None
 
     # Call all functions that check whether log_stats is disabled.
-    req = make_request("0", list(range(16)), block_size, hash)
+    req = make_request("0", list(range(16)), block_size)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
     assert not computed_blocks.blocks[0]
     assert num_computed_tokens == 0
@@ -1120,15 +1081,9 @@ def test_prefix_cache_stats_disabled():
 
 def test_maybe_evict_cached_block():
     pool = BlockPool(num_gpu_blocks=4, enable_caching=True)
-    block_hash0 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=10,
-                                                            token_ids=(100, )),
-                                       group_id=1000)
-    block_hash1 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=20,
-                                                            token_ids=(200, )),
-                                       group_id=2000)
-    block_hash2 = BlockHashWithGroupId(block_hash=BlockHash(hash_value=30,
-                                                            token_ids=(300, )),
-                                       group_id=3000)
+    block_hash0 = "10:1000"
+    block_hash1 = "20:2000"
+    block_hash2 = "30:3000"
     block_hashes = [
         block_hash0,
         block_hash1,
@@ -1202,7 +1157,7 @@ def test_kv_cache_events(blocks_to_cache: int):
     )
 
     num_tokens = block_size * blocks_to_cache
-    req0 = make_request("0", list(range(num_tokens)), block_size, hash)
+    req0 = make_request("0", list(range(num_tokens)), block_size)
     _ = manager.allocate_slots(req0, num_tokens)
     events = manager.take_events()
 
@@ -1218,7 +1173,7 @@ def test_kv_cache_events(blocks_to_cache: int):
     # Should see block_to_cache number of removed block events and a new block
     # stored event
     manager.free(req0)
-    req1 = make_request("1", list(range(num_tokens)), block_size, hash)
+    req1 = make_request("1", list(range(num_tokens)), block_size)
     _ = manager.allocate_slots(req1, num_tokens)
     events = manager.take_events()
 
@@ -1252,7 +1207,7 @@ def test_eagle_enabled_removes_last_block():
 
     # Request with 3 full blocks (48 tokens)
     token_ids = [0] * (3 * block_size)
-    req = make_request("divisible_request", token_ids, block_size, hash)
+    req = make_request("divisible_request", token_ids, block_size)
 
     # Prime the cache
     computed_blocks, _ = manager.get_computed_blocks(req)
@@ -1262,7 +1217,7 @@ def test_eagle_enabled_removes_last_block():
     manager.free(req)
 
     # New request with same tokens + Eagle enabled
-    req_eagle = make_request("eagle_divisible", token_ids, block_size, hash)
+    req_eagle = make_request("eagle_divisible", token_ids, block_size)
     computed_blocks, num_tokens = manager.get_computed_blocks(req_eagle)
 
     # Should retain 1 block:
@@ -1283,7 +1238,7 @@ def test_eagle_with_partial_blocks():
     )
     # 2 full blocks + 5 tokens (non-divisible length)
     token_ids = [0] * (2 * block_size + 5)
-    req = make_request("partial_block_test", token_ids, block_size, hash)
+    req = make_request("partial_block_test", token_ids, block_size)
 
     # Prime the cache
     computed_blocks, _ = manager.get_computed_blocks(req)
@@ -1293,7 +1248,7 @@ def test_eagle_with_partial_blocks():
     manager.free(req)
 
     # New request with Eagle enabled
-    req_eagle = make_request("partial_eagle", token_ids, block_size, hash)
+    req_eagle = make_request("partial_eagle", token_ids, block_size)
     computed_blocks, num_tokens = manager.get_computed_blocks(req_eagle)
     # Original match: 2 full blocks → Eagle removes 1 → 1 remaining
     assert len(computed_blocks.blocks[0]) == 1
@@ -1324,7 +1279,7 @@ def test_eagle_with_sliding_window():
 
     # 2 full blocks + 5 tokens (non-divisible length)
     token_ids = [0] * (2 * block_size + 5)
-    req = make_request("partial_block_test", token_ids, block_size, hash)
+    req = make_request("partial_block_test", token_ids, block_size)
 
     # Prime the cache
     computed_blocks, _ = manager.get_computed_blocks(req)
@@ -1337,7 +1292,7 @@ def test_eagle_with_sliding_window():
     manager.free(req)
 
     # New request with Eagle enabled
-    req_eagle = make_request("partial_eagle", token_ids, block_size, hash)
+    req_eagle = make_request("partial_eagle", token_ids, block_size)
     computed_blocks, num_tokens = manager.get_computed_blocks(req_eagle)
     # Original match: 2 full blocks → Eagle removes 1 → 1 remaining
     assert len(computed_blocks.blocks[0]) == 1
@@ -1347,11 +1302,11 @@ def test_eagle_with_sliding_window():
     assert manager.block_pool.get_cached_block(
         block_hash_first_block, kv_cache_group_ids=[0]) is not None
     manager.block_pool.cached_block_hash_to_block.pop(
-        BlockHashWithGroupId(block_hash_first_block, 0))
+        f"{block_hash_first_block}:0")
 
     # New request
     req_after_evict = make_request("partial_eagle_after_evict", token_ids,
-                                   block_size, hash)
+                                   block_size)
     computed_blocks, num_tokens = manager.get_computed_blocks(req_after_evict)
     # Cache miss. The only hit prefix is [NULL_BLOCK, BLOCK_2] if eagle is
     # not considered. But after dropping the last matched block due to eagle,

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -6,8 +6,7 @@ import random
 import torch
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
-                                         KVCacheBlock)
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager, SlidingWindowManager)
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
@@ -43,9 +42,7 @@ def test_chunked_local_attention_possible_cached_prefix():
                                                   block_pool)
 
     def run_one_case(block_is_cached, tail_token, expect_length):
-        block_hash_list = [
-            BlockHash(i, ()) for i in range(len(block_is_cached))
-        ]
+        block_hash_list = [str(i) for i in range(len(block_is_cached))]
 
         block_pool.cached_block_hash_to_block.clear()
 
@@ -53,8 +50,7 @@ def test_chunked_local_attention_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[BlockHashWithGroupId(
-                    block_hash, 0)] = {
+                block_pool.cached_block_hash_to_block[f"{block_hash}:0"] = {
                         i: block_pool.blocks[i + 10],
                     }
 
@@ -108,9 +104,7 @@ def test_sliding_window_possible_cached_prefix():
     manager = get_sliding_window_manager(sliding_window_spec, block_pool)
 
     def run_one_case(block_is_cached, expect_length):
-        block_hash_list = [
-            BlockHash(i, ()) for i in range(len(block_is_cached))
-        ]
+        block_hash_list = [str(i) for i in range(len(block_is_cached))]
 
         block_pool.cached_block_hash_to_block.clear()
 
@@ -118,8 +112,7 @@ def test_sliding_window_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[BlockHashWithGroupId(
-                    block_hash, 0)] = {
+                block_pool.cached_block_hash_to_block[f"{block_hash}:0"] = {
                         i: block_pool.blocks[i + 10],
                     }
 

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -42,7 +42,7 @@ def test_chunked_local_attention_possible_cached_prefix():
                                                   block_pool)
 
     def run_one_case(block_is_cached, tail_token, expect_length):
-        block_hash_list = [str(i) for i in range(len(block_is_cached))]
+        block_hash_list = [str(i).encode() for i in range(len(block_is_cached))]
 
         block_pool.cached_block_hash_to_block.clear()
 
@@ -50,7 +50,7 @@ def test_chunked_local_attention_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[f"{block_hash}:0"] = {
+                block_pool.cached_block_hash_to_block[block_hash + b":0"] = {
                         i: block_pool.blocks[i + 10],
                     }
 
@@ -104,7 +104,7 @@ def test_sliding_window_possible_cached_prefix():
     manager = get_sliding_window_manager(sliding_window_spec, block_pool)
 
     def run_one_case(block_is_cached, expect_length):
-        block_hash_list = [str(i) for i in range(len(block_is_cached))]
+        block_hash_list = [str(i).encode() for i in range(len(block_is_cached))]
 
         block_pool.cached_block_hash_to_block.clear()
 
@@ -112,7 +112,7 @@ def test_sliding_window_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[f"{block_hash}:0"] = {
+                block_pool.cached_block_hash_to_block[block_hash + b":0"] = {
                         i: block_pool.blocks[i + 10],
                     }
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -129,10 +129,10 @@ def create_requests(
 ) -> list[Request]:
     global _none_hash_initialized
     if not _none_hash_initialized:
-        init_none_hash(hash)
+        init_none_hash()
         _none_hash_initialized = True
 
-    block_hasher = get_request_block_hasher(block_size, hash)
+    block_hasher = get_request_block_hasher(block_size)
     sampling_params = SamplingParams(ignore_eos=False,
                                      max_tokens=max_tokens,
                                      stop_token_ids=stop_token_ids,

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import tempfile
 from collections import defaultdict
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import torch
 
@@ -126,12 +126,11 @@ def create_request(request_id: int,
                    do_remote_prefill: bool = False,
                    use_all_1s_for_prompt_tokens: bool = False,
                    num_remote_blocks: int = 3,
-                   block_size: int = 16,
-                   hash_fn: Callable = hash) -> Request:
+                   block_size: int = 16) -> Request:
     """Make dummy request for testing."""
     global _none_hash_initialized
     if not _none_hash_initialized:
-        init_none_hash(hash)
+        init_none_hash()
         _none_hash_initialized = True
 
     kv_transfer_params: Optional[dict[str, Any]] = None
@@ -166,7 +165,7 @@ def create_request(request_id: int,
         multi_modal_placeholders=None,
         multi_modal_hashes=None,
         eos_token_id=EOS_TOKEN_ID,
-        block_hasher=get_request_block_hasher(block_size, hash_fn),
+        block_hasher=get_request_block_hasher(block_size),
     )
     req.kv_transfer_params = kv_transfer_params
     return req

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -41,15 +41,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[int]
-    parent_block_hash: Optional[int]
+    block_hashes: list[str]
+    parent_block_hash: Optional[str]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[int]
+    block_hashes: list[str]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -41,15 +41,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[str]
-    parent_block_hash: Optional[str]
+    block_hashes: list[bytes]
+    parent_block_hash: Optional[bytes]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[str]
+    block_hashes: list[bytes]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -7,8 +7,7 @@ from typing import Optional
 from vllm.distributed.kv_events import (AllBlocksCleared, BlockRemoved,
                                         BlockStored, KVCacheEvent)
 from vllm.logger import init_logger
-from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
-                                         FreeKVCacheBlockQueue, KVCacheBlock)
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
@@ -55,8 +54,9 @@ class BlockPool:
         # if there is already an identical block in the cache. This is because
         # we want to make sure the allocated block IDs won't change so that
         # block tables are append-only.
-        self.cached_block_hash_to_block: dict[BlockHashWithGroupId, dict[
-            int, KVCacheBlock]] = defaultdict(dict)
+        # The key is a string ``"{hash}:{group_id}"``.
+        self.cached_block_hash_to_block: dict[str, dict[int, KVCacheBlock]] = (
+            defaultdict(dict))
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
@@ -68,7 +68,7 @@ class BlockPool:
         self.kv_event_queue: list[KVCacheEvent] = []
 
     def get_cached_block(
-            self, block_hash: BlockHash,
+            self, block_hash: str,
             kv_cache_group_ids: list[int]) -> Optional[list[KVCacheBlock]]:
         """Get the cached block by the block hash for each group in 
         `kv_cache_group_ids`, or None if cache miss for any group.
@@ -83,8 +83,8 @@ class BlockPool:
         """
         cached_blocks = []
         for group_id in kv_cache_group_ids:
-            cached_blocks_one_group = self.cached_block_hash_to_block.get(
-                BlockHashWithGroupId(block_hash, group_id))
+            key = f"{block_hash}:{group_id}"
+            cached_blocks_one_group = self.cached_block_hash_to_block.get(key)
             if not cached_blocks_one_group:
                 return None
             first_block = next(iter(cached_blocks_one_group.values()))
@@ -123,20 +123,18 @@ class BlockPool:
         assert len(request.block_hashes) >= num_full_blocks
         new_block_hashes = request.block_hashes[num_cached_blocks:]
 
-        new_hashes: Optional[list[int]] = ([] if self.enable_kv_cache_events
+        new_hashes: Optional[list[str]] = ([] if self.enable_kv_cache_events
                                            else None)
         for i, blk in enumerate(new_full_blocks):
             assert blk.block_hash is None
             block_hash = new_block_hashes[i]
 
             # Update and added the full block to the cache.
-            block_hash_with_group_id = BlockHashWithGroupId(
-                block_hash, kv_cache_group_id)
-            blk.block_hash = block_hash_with_group_id
-            self.cached_block_hash_to_block[block_hash_with_group_id][
-                blk.block_id] = blk
+            key = f"{block_hash}:{kv_cache_group_id}"
+            blk.block_hash = key
+            self.cached_block_hash_to_block[key][blk.block_id] = blk
             if new_hashes is not None:
-                new_hashes.append(block_hash.hash_value)
+                new_hashes.append(block_hash)
 
         if self.enable_kv_cache_events:
             if num_cached_blocks == 0:
@@ -144,7 +142,7 @@ class BlockPool:
             else:
                 parent_block = blocks[num_cached_blocks - 1]
                 assert parent_block.block_hash is not None
-                parent_block_hash = parent_block.block_hash.get_hash_value()
+                parent_block_hash = parent_block.block_hash.split(":")[0]
 
             self.kv_event_queue.append(
                 BlockStored(
@@ -218,7 +216,7 @@ class BlockPool:
             # we disable hybrid kv cache manager when kv cache event is
             # enabled, so there is only one group.
             self.kv_event_queue.append(
-                BlockRemoved(block_hashes=[block_hash.get_hash_value()]))
+                BlockRemoved(block_hashes=[block_hash.split(":")[0]]))
         return True
 
     def touch(self, blocks: tuple[list[KVCacheBlock], ...]) -> None:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager, get_manager_for_kv_cache_spec)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -165,7 +165,7 @@ class KVCacheCoordinator(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         self,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         pass
@@ -191,7 +191,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         blocks: tuple[list[KVCacheBlock], ...] = tuple(
@@ -219,7 +219,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
@@ -314,7 +314,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         """

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -165,7 +165,7 @@ class KVCacheCoordinator(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         self,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         pass
@@ -191,7 +191,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         blocks: tuple[list[KVCacheBlock], ...] = tuple(
@@ -219,7 +219,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
@@ -314,7 +314,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         """

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2,15 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """KV-Cache Utilities."""
 
+import hashlib
 import os
 from collections import defaultdict, deque
 from collections.abc import Iterable, Sequence
 from dataclasses import astuple, dataclass
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Optional
+
+import cbor2
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils import GiB_bytes, cdiv, sha256_cbor_64bit
+from vllm.utils import GiB_bytes, cdiv
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
                                         FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheSpec,
@@ -21,56 +24,26 @@ from vllm.v1.request import Request
 logger = init_logger(__name__)
 
 
-class BlockHash(NamedTuple):
-    """Hash value of a block (int), the token IDs in the block, and extra keys.
-    We keep a tuple of token IDs and extra keys to reduce the likelihood of
-    hash collisions when the hash value is the same. By using SHA256 however,
-    hash collisions are practically impossible.
-    """
-    # Hash value of the block in an integer.
-    hash_value: int
-    # Token IDs in the block.
-    token_ids: tuple[int, ...]
-    # Extra keys for the block.
-    extra_keys: Optional[Any] = None
-
-
-class BlockHashWithGroupId(NamedTuple):
-    # The hash value for the contents (e.g., token_ids) of a block without group
-    # ID. The value is the same for blocks representing the same tokens but for
-    # different groups.
-    block_hash: BlockHash
-    # The KV cache group ID.
-    group_id: int
-
-    def get_hash_value(self) -> int:
-        return self.block_hash.hash_value
-
-
 # The hash seed for the first block of any prefix block sequence.
 #
 # We use a random value to avoid hash collisions or PYTHONHASHSEED environment
-# variable if set such that processes can share the seed if needed.
-# This aligns with the behavior of Python's hash() function, which also uses
-# a random seed if PYTHONHASHSEED is not set.
+# variable if set such that processes can share the seed if needed. This aligns
+# with the behavior of Python's hash() function, which also uses a random seed
+# if PYTHONHASHSEED is not set.
 #
 # The function `init_none_hash` initializes this variable globally.
-NONE_HASH: int
+NONE_HASH: str
 
 
-def init_none_hash(hash_fn: Callable):
+def init_none_hash() -> None:
+    """Initialize the seed hash used for the first block in a sequence."""
     global NONE_HASH
 
     hash_seed = os.getenv("PYTHONHASHSEED")
-    if hash_seed is None and hash_fn is sha256_cbor_64bit:
-        logger.warning(
-            "PYTHONHASHSEED is not set. This will lead to non-reproducible "
-            "block-hashes when using sha256_cbor_64bit as the hash function."
-            "Consider setting PYTHONHASHSEED to a fixed value for "
-            "reproducibility.")
-
-    NONE_HASH = (int.from_bytes(os.urandom(32), byteorder="big")
-                 if hash_seed is None else hash_fn(hash_seed))
+    if hash_seed is None:
+        NONE_HASH = hashlib.sha256(os.urandom(32)).hexdigest()
+    else:
+        NONE_HASH = hashlib.sha256(hash_seed.encode()).hexdigest()
 
 
 class PrefixCachingMetrics:
@@ -142,9 +115,9 @@ class KVCacheBlock:
     block_id: int
     # Reference count.
     ref_cnt: int = 0
-    # The hash of the block composed of (block hash, tuple of token IDs).
+    # The hash of the block composed of (block hash, kv cache group id).
     # It is only available when the block is full.
-    _block_hash: Optional[BlockHashWithGroupId] = None
+    _block_hash: Optional[str] = None
 
     # Used to construct a doubly linked list for free blocks.
     # These two attributes should only be manipulated by FreeKVCacheBlockQueue.
@@ -155,11 +128,11 @@ class KVCacheBlock:
     is_null: bool = False
 
     @property
-    def block_hash(self) -> Optional[BlockHashWithGroupId]:
+    def block_hash(self) -> Optional[str]:
         return self._block_hash
 
     @block_hash.setter
-    def block_hash(self, block_hash: BlockHashWithGroupId):
+    def block_hash(self, block_hash: str):
         assert self.block_hash is None, (
             "The block already has a hash. This should not happen.")
         self._block_hash = block_hash
@@ -517,54 +490,42 @@ def generate_block_hash_extra_keys(
 
 
 def hash_block_tokens(
-        hash_function: Callable,
-        parent_block_hash: Optional[int],
+        parent_block_hash: Optional[str],
         curr_block_token_ids: Sequence[int],
-        extra_keys: Optional[tuple[Any, ...]] = None) -> BlockHash:
-    """Computes a hash value corresponding to the contents of a block and
-    the contents of the preceding block(s). The hash value is used for
-    prefix caching. We use LRU cache for this function to avoid recomputing
-    hash values for the same block contents.
+        extra_keys: Optional[tuple[Any, ...]] = None) -> str:
+    """Compute a SHA-256 hash for a block of tokens.
+
+    The hash is deterministically derived from the previous block's hash,
+    the token ids of the current block, and any extra keys. The resulting
+    value is returned as a hexadecimal string.
 
     Args:
-        parent_block_hash: The hash of the parent block. None
-            if this is the first block.
-        curr_block_token_ids: A list of token ids in the current
-            block. The current block is assumed to be full.
+        parent_block_hash: The hash of the parent block. ``None`` if this is
+            the first block in the sequence.
+        curr_block_token_ids: A list of token ids in the current block. The
+            current block is assumed to be full.
         extra_keys: Extra keys for the block.
 
     Returns:
-        The hash value of the block and the token ids in the block.
-        The entire tuple is used as the hash key of the block.
+        A SHA-256 hexadecimal string representing the block's contents.
     """
     if not parent_block_hash:
         parent_block_hash = NONE_HASH
 
     curr_block_token_ids_tuple = tuple(curr_block_token_ids)
-    return BlockHash(
-        hash_function(
-            (parent_block_hash, curr_block_token_ids_tuple, extra_keys)),
-        curr_block_token_ids_tuple, extra_keys)
+    input_bytes = cbor2.dumps(
+        (parent_block_hash, curr_block_token_ids_tuple, extra_keys),
+        canonical=True,
+    )
+    return hashlib.sha256(input_bytes).hexdigest()
 
 
 def get_request_block_hasher(
     block_size: int,
-    caching_hash_fn: Callable[[Any],
-                              int]) -> Callable[[Request], list[BlockHash]]:
-    """
-    Returns a function which computes the list of un-computed block hashes
-    of a request.
+) -> Callable[[Request], list[str]]:
+    """Return a function that computes uncomputed block hashes for a request."""
 
-    Each request holds a list of its block hashes (request.block_hashes).
-    When a request is created, it calls the below function to compute
-    the hashes of all full blocks of the request's initial tokens.
-    The hashes are then stored in request.block_hashes.
-    Later, whenever new tokens are appended to the request, it calls
-    the below function again to compute any new full blocks of tokens.
-    The returned new hashes are appended to request.block_hashes.
-    """
-
-    def request_block_hasher(request: Request) -> list[BlockHash]:
+    def request_block_hasher(request: Request) -> list[str]:
         start_token_idx = len(request.block_hashes) * block_size
         num_tokens = request.num_tokens
 
@@ -576,9 +537,9 @@ def get_request_block_hasher(
             # last mm input.
             curr_mm_idx = -1
 
-        prev_block_hash_value = request.block_hashes[-1].hash_value \
+        prev_block_hash_value = request.block_hashes[-1] \
             if request.block_hashes else None
-        new_block_hashes: list[BlockHash] = []
+        new_block_hashes: list[str] = []
         while True:
             end_token_idx = start_token_idx + block_size
             if end_token_idx > num_tokens:
@@ -591,13 +552,12 @@ def get_request_block_hasher(
 
             # Compute the hash of the current block
             block_tokens = request.all_token_ids[start_token_idx:end_token_idx]
-            block_hash = hash_block_tokens(caching_hash_fn,
-                                           prev_block_hash_value, block_tokens,
+            block_hash = hash_block_tokens(prev_block_hash_value, block_tokens,
                                            extra_keys)
 
             new_block_hashes.append(block_hash)
             start_token_idx += block_size
-            prev_block_hash_value = block_hash.hash_value
+            prev_block_hash_value = block_hash
 
         return new_block_hashes
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -189,7 +189,7 @@ class SingleTypeKVCacheManager(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -246,7 +246,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -303,7 +303,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -401,7 +401,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -518,7 +518,7 @@ class MambaManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[str],
+        block_hashes: list[bytes],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from vllm.utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
                                         FullAttentionSpec, KVCacheSpec,
                                         MambaSpec, SlidingWindowSpec)
@@ -189,7 +189,7 @@ class SingleTypeKVCacheManager(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -246,7 +246,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -303,7 +303,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -401,7 +401,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -518,7 +518,7 @@ class MambaManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: list[str],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -25,9 +25,9 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
-from vllm.utils import (decorate_logs, get_hash_fn_by_name, make_zmq_socket,
-                        resolve_obj_by_qualname, set_process_title)
-from vllm.v1.core.kv_cache_utils import (BlockHash, get_kv_cache_config,
+from vllm.utils import (decorate_logs, make_zmq_socket, resolve_obj_by_qualname,
+                        set_process_title)
+from vllm.v1.core.kv_cache_utils import (get_kv_cache_config,
                                          get_request_block_hasher,
                                          init_none_hash,
                                          unify_kv_cache_configs)
@@ -144,17 +144,14 @@ class EngineCore:
             self.batch_queue = queue.Queue(self.batch_queue_size)
 
         self.request_block_hasher: Optional[Callable[[Request],
-                                                     list[BlockHash]]] = None
+                                                     list[str]]] = None
         if (self.vllm_config.cache_config.enable_prefix_caching
                 or self.scheduler.get_kv_connector() is not None):
 
             block_size = vllm_config.cache_config.block_size
-            caching_hash_fn = get_hash_fn_by_name(
-                vllm_config.cache_config.prefix_caching_hash_algo)
-            init_none_hash(caching_hash_fn)
+            init_none_hash()
 
-            self.request_block_hasher = get_request_block_hasher(
-                block_size, caching_hash_fn)
+            self.request_block_hasher = get_request_block_hasher(block_size)
 
     def _initialize_kv_caches(
             self, vllm_config: VllmConfig) -> tuple[int, int, KVCacheConfig]:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -17,7 +17,6 @@ from vllm.v1.utils import ConstantList
 
 if TYPE_CHECKING:
     from vllm.lora.request import LoRARequest
-    from vllm.v1.core.kv_cache_utils import BlockHash
 
 
 class Request:
@@ -38,8 +37,7 @@ class Request:
         structured_output_request: Optional["StructuredOutputRequest"] = None,
         cache_salt: Optional[str] = None,
         priority: int = 0,
-        block_hasher: Optional[Callable[["Request"],
-                                        list["BlockHash"]]] = None,
+        block_hasher: Optional[Callable[["Request"], list[str]]] = None,
     ) -> None:
         self.request_id = request_id
         self.client_index = client_index
@@ -114,9 +112,9 @@ class Request:
         # indicates that the output is corrupted
         self.num_nans_in_logits = 0
 
-        self.block_hashes: list[BlockHash] = []
+        self.block_hashes: list[str] = []
         self.get_hash_new_full_blocks: Optional[Callable[
-            [], list[BlockHash]]] = None
+            [], list[str]]] = None
         if block_hasher is not None:
             self.get_hash_new_full_blocks = partial(block_hasher, self)
             self.block_hashes = self.get_hash_new_full_blocks()
@@ -124,7 +122,7 @@ class Request:
     @classmethod
     def from_engine_core_request(
         cls, request: EngineCoreRequest,
-        block_hasher: Optional[Callable[["Request"], list["BlockHash"]]]
+        block_hasher: Optional[Callable[["Request"], list[str]]]
     ) -> "Request":
         if request.mm_kwargs is not None:
             mm_kwargs_lst = list(request.mm_kwargs)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -37,7 +37,7 @@ class Request:
         structured_output_request: Optional["StructuredOutputRequest"] = None,
         cache_salt: Optional[str] = None,
         priority: int = 0,
-        block_hasher: Optional[Callable[["Request"], list[str]]] = None,
+        block_hasher: Optional[Callable[["Request"], list[bytes]]] = None,
     ) -> None:
         self.request_id = request_id
         self.client_index = client_index
@@ -112,9 +112,9 @@ class Request:
         # indicates that the output is corrupted
         self.num_nans_in_logits = 0
 
-        self.block_hashes: list[str] = []
+        self.block_hashes: list[bytes] = []
         self.get_hash_new_full_blocks: Optional[Callable[
-            [], list[str]]] = None
+            [], list[bytes]]] = None
         if block_hasher is not None:
             self.get_hash_new_full_blocks = partial(block_hasher, self)
             self.block_hashes = self.get_hash_new_full_blocks()
@@ -122,7 +122,7 @@ class Request:
     @classmethod
     def from_engine_core_request(
         cls, request: EngineCoreRequest,
-        block_hasher: Optional[Callable[["Request"], list[str]]]
+        block_hasher: Optional[Callable[["Request"], list[bytes]]]
     ) -> "Request":
         if request.mm_kwargs is not None:
             mm_kwargs_lst = list(request.mm_kwargs)


### PR DESCRIPTION
## Summary
- replace BlockHash NamedTuples with raw SHA-256 hex strings
- key cached blocks by "hash:group" and update cache events
- store request block hashes as strings and adjust tests

## Testing
- `pytest tests/v1/core/test_kv_cache_utils.py tests/v1/core/test_prefix_caching.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ac7348a4e4832ab552a1b38a58e9c2