### PR TITLE
refactor: add typed block hash aliases

### DIFF
--- a/examples/online_serving/kv_events_subscriber.py
+++ b/examples/online_serving/kv_events_subscriber.py
@@ -6,6 +6,8 @@ import msgspec
 import zmq
 from msgspec.msgpack import Decoder
 
+from vllm.v1.core.kv_cache_utils import BlockHash
+
 
 #
 # Types copied from vllm.distributed.kv_events
@@ -22,15 +24,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[bytes]
-    parent_block_hash: Optional[bytes]
+    block_hashes: list[BlockHash]
+    parent_block_hash: Optional[BlockHash]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[bytes]
+    block_hashes: list[BlockHash]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -6,8 +6,7 @@ import random
 import torch
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import (KVCacheBlock,
-                                         get_block_hash_with_group_id)
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashKey, KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager, SlidingWindowManager)
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
@@ -44,7 +43,7 @@ def test_chunked_local_attention_possible_cached_prefix():
 
     def run_one_case(block_is_cached, tail_token, expect_length):
         block_hash_list = [
-            str(i).encode() for i in range(len(block_is_cached))
+            BlockHash(str(i).encode()) for i in range(len(block_is_cached))
         ]
 
         block_pool.cached_block_hash_to_block.clear()
@@ -53,8 +52,8 @@ def test_chunked_local_attention_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[
-                    get_block_hash_with_group_id(block_hash, 0)] = {
+                block_pool.cached_block_hash_to_block[BlockHashKey(
+                    (block_hash, 0))] = {
                         i: block_pool.blocks[i + 10],
                     }
 
@@ -109,7 +108,7 @@ def test_sliding_window_possible_cached_prefix():
 
     def run_one_case(block_is_cached, expect_length):
         block_hash_list = [
-            str(i).encode() for i in range(len(block_is_cached))
+            BlockHash(str(i).encode()) for i in range(len(block_is_cached))
         ]
 
         block_pool.cached_block_hash_to_block.clear()
@@ -118,8 +117,8 @@ def test_sliding_window_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[
-                    get_block_hash_with_group_id(block_hash, 0)] = {
+                block_pool.cached_block_hash_to_block[BlockHashKey(
+                    (block_hash, 0))] = {
                         i: block_pool.blocks[i + 10],
                     }
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -16,6 +16,7 @@ import zmq
 
 from vllm.config import KVEventsConfig
 from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_utils import BlockHash
 
 logger = init_logger(__name__)
 
@@ -41,15 +42,15 @@ class KVCacheEvent(
 
 
 class BlockStored(KVCacheEvent):
-    block_hashes: list[bytes]
-    parent_block_hash: Optional[bytes]
+    block_hashes: list[BlockHash]
+    parent_block_hash: Optional[BlockHash]
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
 
 
 class BlockRemoved(KVCacheEvent):
-    block_hashes: list[bytes]
+    block_hashes: list[BlockHash]
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -2,14 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Optional
+from typing import Optional, cast
 
 from vllm.distributed.kv_events import (AllBlocksCleared, BlockRemoved,
                                         BlockStored, KVCacheEvent)
 from vllm.logger import init_logger
-from vllm.v1.core.kv_cache_utils import (FreeKVCacheBlockQueue, KVCacheBlock,
-                                         get_block_hash_with_group_id,
-                                         strip_group_id)
+from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashKey,
+                                         FreeKVCacheBlockQueue, KVCacheBlock)
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
@@ -47,17 +46,16 @@ class BlockPool:
         # enabled).
         self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
 
-        # {block_hash: {block ID: block}}. A cached block is
-        # a full block with a block hash that can be used for prefix caching.
-        # The cached block may be used by running requests or in the
-        # free_block_queue that could potentially be evicted.
-        # NOTE: We currently don't de-duplicate the blocks in the cache,
-        # meaning that if a block becomes full and is cached, we don't check
-        # if there is already an identical block in the cache. This is because
-        # we want to make sure the allocated block IDs won't change so that
-        # block tables are append-only.
-        # The key is bytes ``hash + b":" + group_id.to_bytes(4, "little")``.
-        self.cached_block_hash_to_block: dict[bytes,
+        # {BlockHashKey: {block ID: block}}. A cached block is a full block
+        # whose hash (combined with its group id) can be used for prefix
+        # caching. The cached block may be used by running requests or in the
+        # free_block_queue that could potentially be evicted.  NOTE: We
+        # currently don't de-duplicate the blocks in the cache, meaning that if
+        # a block becomes full and is cached, we don't check if there is
+        # already an identical block in the cache. This is because we want to
+        # make sure the allocated block IDs won't change so that block tables
+        # are append-only.
+        self.cached_block_hash_to_block: dict[BlockHashKey,
                                               dict[int, KVCacheBlock]] = (
                                                   defaultdict(dict))
 
@@ -71,7 +69,7 @@ class BlockPool:
         self.kv_event_queue: list[KVCacheEvent] = []
 
     def get_cached_block(
-            self, block_hash: bytes,
+            self, block_hash: BlockHash,
             kv_cache_group_ids: list[int]) -> Optional[list[KVCacheBlock]]:
         """Get the cached block by the block hash for each group in 
         `kv_cache_group_ids`, or None if cache miss for any group.
@@ -86,7 +84,7 @@ class BlockPool:
         """
         cached_blocks = []
         for group_id in kv_cache_group_ids:
-            key = get_block_hash_with_group_id(block_hash, group_id)
+            key = BlockHashKey((block_hash, group_id))
             cached_blocks_one_group = self.cached_block_hash_to_block.get(key)
             if not cached_blocks_one_group:
                 return None
@@ -126,14 +124,14 @@ class BlockPool:
         assert len(request.block_hashes) >= num_full_blocks
         new_block_hashes = request.block_hashes[num_cached_blocks:]
 
-        new_hashes: Optional[list[bytes]] = ([] if self.enable_kv_cache_events
-                                             else None)
+        new_hashes: Optional[list[BlockHash]] = (
+            [] if self.enable_kv_cache_events else None)
         for i, blk in enumerate(new_full_blocks):
             assert blk.block_hash is None
             block_hash = new_block_hashes[i]
 
             # Update and added the full block to the cache.
-            key = get_block_hash_with_group_id(block_hash, kv_cache_group_id)
+            key = BlockHashKey((block_hash, kv_cache_group_id))
             blk.block_hash = key
             self.cached_block_hash_to_block[key][blk.block_id] = blk
             if new_hashes is not None:
@@ -141,11 +139,11 @@ class BlockPool:
 
         if self.enable_kv_cache_events:
             if num_cached_blocks == 0:
-                parent_block_hash = None
+                parent_block_hash: Optional[BlockHash] = None
             else:
                 parent_block = blocks[num_cached_blocks - 1]
                 assert parent_block.block_hash is not None
-                parent_block_hash = strip_group_id(parent_block.block_hash)
+                parent_block_hash = parent_block.block_hash[0]
 
             self.kv_event_queue.append(
                 BlockStored(
@@ -219,7 +217,7 @@ class BlockPool:
             # we disable hybrid kv cache manager when kv cache event is
             # enabled, so there is only one group.
             self.kv_event_queue.append(
-                BlockRemoved(block_hashes=[strip_group_id(block_hash)]))
+                BlockRemoved(block_hashes=[block_hash[0]]))
         return True
 
     def touch(self, blocks: tuple[list[KVCacheBlock], ...]) -> None:
@@ -272,7 +270,8 @@ class BlockPool:
             return False
 
         # Remove all hashes so that no new blocks will hit.
-        self.cached_block_hash_to_block = defaultdict(dict)
+        self.cached_block_hash_to_block = cast(
+            dict[BlockHashKey, dict[int, KVCacheBlock]], defaultdict(dict))
 
         # Remove all hashes from all blocks.
         for block in self.blocks:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager, get_manager_for_kv_cache_spec)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -165,7 +165,7 @@ class KVCacheCoordinator(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         self,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         pass
@@ -191,7 +191,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         blocks: tuple[list[KVCacheBlock], ...] = tuple(
@@ -219,7 +219,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
@@ -314,7 +314,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
     def find_longest_cache_hit(
         self,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from vllm.utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
                                         FullAttentionSpec, KVCacheSpec,
                                         MambaSpec, SlidingWindowSpec)
@@ -189,7 +189,7 @@ class SingleTypeKVCacheManager(ABC):
     @abstractmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -246,7 +246,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -303,7 +303,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -401,7 +401,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
@@ -518,7 +518,7 @@ class MambaManager(SingleTypeKVCacheManager):
     @classmethod
     def find_longest_cache_hit(
         cls,
-        block_hashes: list[bytes],
+        block_hashes: list[BlockHash],
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -27,7 +27,7 @@ from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.utils import (decorate_logs, get_hash_fn_by_name, make_zmq_socket,
                         resolve_obj_by_qualname, set_process_title)
-from vllm.v1.core.kv_cache_utils import (get_kv_cache_config,
+from vllm.v1.core.kv_cache_utils import (BlockHash, get_kv_cache_config,
                                          get_request_block_hasher,
                                          init_none_hash,
                                          unify_kv_cache_configs)
@@ -144,7 +144,7 @@ class EngineCore:
             self.batch_queue = queue.Queue(self.batch_queue_size)
 
         self.request_block_hasher: Optional[Callable[[Request],
-                                                     list[bytes]]] = None
+                                                     list[BlockHash]]] = None
         if (self.vllm_config.cache_config.enable_prefix_caching
                 or self.scheduler.get_kv_connector() is not None):
 


### PR DESCRIPTION
## Summary
- define `BlockHash` and `BlockHashKey` for prefix cache hashing
- use typed block hashes across cache helpers and events, removing group-id helpers

## Testing
- `SKIP=actionlint,mypy-local pre-commit run --files vllm/v1/core/kv_cache_utils.py vllm/v1/core/block_pool.py vllm/distributed/kv_events.py vllm/v1/request.py vllm/v1/engine/core.py vllm/v1/core/kv_cache_coordinator.py vllm/v1/core/single_type_kv_cache_manager.py tests/v1/core/test_prefix_caching.py tests/v1/core/test_single_type_kv_cache_manager.py examples/online_serving/kv_events_subscriber.py`
- `mypy vllm/v1/core/kv_cache_utils.py vllm/v1/core/block_pool.py vllm/distributed/kv_events.py vllm/v1/request.py vllm/v1/core/kv_cache_coordinator.py vllm/v1/core/single_type_kv_cache_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad27eceac4832aaaeccb6e20187519