### PR TITLE
Refactor block hash key handling

### DIFF
--- a/docs/design/prefix_caching.md
+++ b/docs/design/prefix_caching.md
@@ -105,9 +105,9 @@ The prefix caching in vLLM v1 is implemented in the KV cache manager. The basic 
 class KVCacheBlock:
     # The block ID (immutable)
     block_id: int
-    # The block hash key (hash + group id) assigned when the block is full,
+    # The block hash with group id assigned when the block is full,
     # and reset when the block is evicted.
-    block_hash_key: BlockHashKey
+    block_hash_with_group_id: BlockHashWithGroupId
     # The number of requests using this block now.
     ref_cnt: int
 

--- a/docs/design/prefix_caching.md
+++ b/docs/design/prefix_caching.md
@@ -107,7 +107,7 @@ class KVCacheBlock:
     block_id: int
     # The block hash with group id assigned when the block is full,
     # and reset when the block is evicted.
-    block_hash_with_group_id: BlockHashWithGroupId
+    block_hash: BlockHashWithGroupId
     # The number of requests using this block now.
     ref_cnt: int
 

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -137,7 +137,7 @@ def test_kv_cache_block():
     block.block_hash = block_hash
     assert block.block_hash == block_hash
 
-    block.reset_block_hash()
+    block.reset_hash()
     assert block.block_hash is None
 
 

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -14,11 +14,22 @@ from vllm.v1.core.kv_cache_manager import KVCacheManager
 # disable yapf here as it formats differently than isort such that both fail
 # yapf: disable
 from vllm.v1.core.kv_cache_utils import (
-    BlockHashKey, FreeKVCacheBlockQueue, KVCacheBlock, PrefixCachingMetrics,
-    estimate_max_model_len, generate_block_hash_extra_keys,
-    get_kv_cache_config, get_max_concurrency_for_kv_cache_config,
-    get_request_block_hasher, hash_block_tokens, init_none_hash,
-    is_kv_cache_type_uniform, unify_kv_cache_configs)
+    BlockHash,
+    BlockHashWithGroupId,
+    FreeKVCacheBlockQueue,
+    KVCacheBlock,
+    PrefixCachingMetrics,
+    estimate_max_model_len,
+    generate_block_hash_extra_keys,
+    get_kv_cache_config,
+    get_max_concurrency_for_kv_cache_config,
+    get_request_block_hasher,
+    hash_block_tokens,
+    init_none_hash,
+    is_kv_cache_type_uniform,
+    make_block_hash_with_group_id,
+    unify_kv_cache_configs,
+)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheTensor,
                                         SlidingWindowSpec)
@@ -113,7 +124,7 @@ def test_kv_cache_block():
     block = KVCacheBlock(block_id=0)
     assert block.block_id == 0
     assert block.ref_cnt == 0
-    assert block.block_hash_key is None
+    assert block.block_hash_with_group_id is None
 
     # Test reference count manipulation
     block.ref_cnt += 1
@@ -122,12 +133,12 @@ def test_kv_cache_block():
     assert block.ref_cnt == 0
 
     # Test block hash setting and resetting
-    block_hash = BlockHashKey((b"abc", 0))
-    block.block_hash_key = block_hash
-    assert block.block_hash_key == block_hash
+    block_hash = make_block_hash_with_group_id(BlockHash(b"abc"), 0)
+    block.block_hash_with_group_id = block_hash
+    assert block.block_hash_with_group_id == block_hash
 
-    block.reset_hash_key()
-    assert block.block_hash_key is None
+    block.reset_block_hash_with_group_id()
+    assert block.block_hash_with_group_id is None
 
 
 def test_free_kv_cache_block_queue_initialization():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -124,7 +124,7 @@ def test_kv_cache_block():
     block = KVCacheBlock(block_id=0)
     assert block.block_id == 0
     assert block.ref_cnt == 0
-    assert block.block_hash_with_group_id is None
+    assert block.block_hash is None
 
     # Test reference count manipulation
     block.ref_cnt += 1
@@ -134,11 +134,11 @@ def test_kv_cache_block():
 
     # Test block hash setting and resetting
     block_hash = make_block_hash_with_group_id(BlockHash(b"abc"), 0)
-    block.block_hash_with_group_id = block_hash
-    assert block.block_hash_with_group_id == block_hash
+    block.block_hash = block_hash
+    assert block.block_hash == block_hash
 
-    block.reset_block_hash_with_group_id()
-    assert block.block_hash_with_group_id is None
+    block.reset_block_hash()
+    assert block.block_hash is None
 
 
 def test_free_kv_cache_block_queue_initialization():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -137,17 +137,15 @@ def test_prefill(hash_fn):
         block_tokens = tuple(all_token_ids[(block_id - 1) * 16:block_id * 16])
         block_hash = hash_block_tokens(hash_fn, parent_block_hash,
                                        block_tokens)
-        blk_hash_with_group_id = (
-            manager.block_pool.blocks[block_id].block_hash_with_group_id)
-        assert blk_hash_with_group_id is not None
-        assert split_block_hash_with_group_id(
-            blk_hash_with_group_id)[0] == block_hash
+        blk_hash = (manager.block_pool.blocks[block_id].block_hash)
+        assert blk_hash is not None
+        assert split_block_hash_with_group_id(blk_hash)[0] == block_hash
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
         parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, ):
-        assert manager.block_pool.blocks[block_id].block_hash_with_group_id is None
+        assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
 
     # Cache hit in the common prefix when the original block is still in use.
@@ -264,17 +262,15 @@ def test_prefill_hybrid_model():
         block_hash = hash_block_tokens(hash_fn, parent_block_hash,
                                        block_tokens)
         for block_id in block_ids:
-            blk_hash_with_group_id = (
-                manager.block_pool.blocks[block_id].block_hash_with_group_id)
-            assert blk_hash_with_group_id is not None
-            assert split_block_hash_with_group_id(
-                blk_hash_with_group_id)[0] == block_hash
+            blk_hash = (manager.block_pool.blocks[block_id].block_hash)
+            assert blk_hash is not None
+            assert split_block_hash_with_group_id(blk_hash)[0] == block_hash
             assert manager.block_pool.blocks[block_id].ref_cnt == 1
         parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, 8, 12):
-        assert manager.block_pool.blocks[block_id].block_hash_with_group_id is None
+        assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
 
     # Cache hit in the common prefix
@@ -396,7 +392,7 @@ def test_prefill_plp():
                                     len(computed_blocks.blocks[0]) * 16,
                                     computed_blocks)
     assert blocks.get_block_ids() == ([1, 2, 3, 4], )
-    req0_block_hashes = [b.block_hash_with_group_id for b in blocks.blocks[0]]
+    req0_block_hashes = [b.block_hash for b in blocks.blocks[0]]
 
     # Check full block metadata
     parent_block_hash = None
@@ -404,17 +400,15 @@ def test_prefill_plp():
         block_tokens = tuple(all_token_ids[(block_id - 1) * 16:block_id * 16])
         block_hash = hash_block_tokens(hash_fn, parent_block_hash,
                                        block_tokens)
-        blk_hash_with_group_id = (
-            manager.block_pool.blocks[block_id].block_hash_with_group_id)
-        assert blk_hash_with_group_id is not None
-        assert split_block_hash_with_group_id(
-            blk_hash_with_group_id)[0] == block_hash
+        blk_hash = (manager.block_pool.blocks[block_id].block_hash)
+        assert blk_hash is not None
+        assert split_block_hash_with_group_id(blk_hash)[0] == block_hash
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
         parent_block_hash = block_hash
 
     # Check partial block metadata
     for block_id in (4, ):
-        assert manager.block_pool.blocks[block_id].block_hash_with_group_id is None
+        assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
 
     # Request #1 is a non-prompt-logprobs request:
@@ -470,7 +464,7 @@ def test_prefill_plp():
                                     computed_blocks)
     block_ids = blocks.get_block_ids()
     # Duplicate cached blocks have different ids but same hashes vs request #0
-    assert [b.block_hash_with_group_id for b in blocks.blocks[0]] == req0_block_hashes
+    assert [b.block_hash for b in blocks.blocks[0]] == req0_block_hashes
     assert block_ids != ([1, 2, 3, 4], )
 
     # Request #2 block hashes are valid since request #0 hashes are.
@@ -514,7 +508,7 @@ def test_decode():
                                         computed_blocks)
     assert new_blocks is not None and len(new_blocks.blocks[0]) == 0
     assert manager.coordinator.single_type_managers[0].req_to_blocks[
-        req0.request_id][-1].block_hash_with_group_id is None
+        req0.request_id][-1].block_hash is None
 
     # Append slots with allocating a new block.
     req0.num_computed_tokens = 59
@@ -527,9 +521,9 @@ def test_decode():
                                         computed_blocks)
     assert new_blocks is not None and len(new_blocks.blocks[0]) == 1
     assert manager.coordinator.single_type_managers[0].req_to_blocks[
-        req0.request_id][-2].block_hash_with_group_id is not None
+        req0.request_id][-2].block_hash is not None
     assert manager.coordinator.single_type_managers[0].req_to_blocks[
-        req0.request_id][-1].block_hash_with_group_id is None
+        req0.request_id][-1].block_hash is None
 
 
 def test_evict():
@@ -624,7 +618,7 @@ def test_hash_block_correct_reuse():
     assert len(blocks.blocks[0]) == 1
 
     assert manager.block_pool.blocks[blocks.blocks[0]
-                                     [0].block_id].block_hash_with_group_id is None
+                                     [0].block_id].block_hash is None
 
 
 def test_computed_blocks_not_evicted():
@@ -762,7 +756,7 @@ def test_cache_blocks(hash_fn):
     )
 
     assert len(block_pool.cached_block_hash_to_block) == 2
-    assert all([block.block_hash_with_group_id is not None for block in blocks])
+    assert all([block.block_hash is not None for block in blocks])
 
     # Test that blocks that don't start from the beginning are cached correctly.
     blocks += [KVCacheBlock(block_id=2)]
@@ -775,7 +769,7 @@ def test_cache_blocks(hash_fn):
         kv_cache_group_id=0,
     )
     assert len(block_pool.cached_block_hash_to_block) == 3
-    assert blocks[0].block_hash_with_group_id is not None
+    assert blocks[0].block_hash is not None
 
 
 def test_cache_blocks_multi_group():
@@ -804,7 +798,7 @@ def test_cache_blocks_multi_group():
     )
     assert len(block_pool.cached_block_hash_to_block) == 2
     assert len(req.block_hashes) == 3
-    assert all([block.block_hash_with_group_id is not None for block in blocks])
+    assert all([block.block_hash is not None for block in blocks])
 
     # Cache the blocks for group 1.
     blocks = [KVCacheBlock(block_id=i) for i in range(3)]
@@ -818,7 +812,7 @@ def test_cache_blocks_multi_group():
     )
     assert len(block_pool.cached_block_hash_to_block) == 5
     assert len(req.block_hashes) == 3
-    assert all([block.block_hash_with_group_id is not None for block in blocks])
+    assert all([block.block_hash is not None for block in blocks])
 
     # Block hash 0: hit for group 0 and 1
     # Block hash 1: hit for group 0 and 1
@@ -1085,7 +1079,7 @@ def test_reset_prefix_cache():
     assert manager.reset_prefix_cache()
     assert not manager.block_pool.cached_block_hash_to_block
     assert all([
-        blk.block_hash_with_group_id is None
+        blk.block_hash is None
         for blk in manager.block_pool.blocks
     ])
 
@@ -1129,10 +1123,9 @@ def test_maybe_evict_cached_block():
     ]
     assert len(pool.blocks) == len(block_hashes)
     # Manually add all blocks to cached_blocks
-    for block, block_hash_with_group_id in zip(pool.blocks, block_hashes):
-        block.block_hash_with_group_id = block_hash_with_group_id
-        pool.cached_block_hash_to_block[block_hash_with_group_id][
-            block.block_id] = block
+    for block, block_hash in zip(pool.blocks, block_hashes):
+        block.block_hash = block_hash
+        pool.cached_block_hash_to_block[block_hash][block.block_id] = block
 
     block0, block1, block2, block3 = pool.blocks
     assert pool.cached_block_hash_to_block == {

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -6,7 +6,9 @@ import random
 import torch
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashKey, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (BlockHash, BlockHashWithGroupId,
+                                         KVCacheBlock,
+                                         make_block_hash_with_group_id)
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager, SlidingWindowManager)
 from vllm.v1.kv_cache_interface import (ChunkedLocalAttentionSpec,
@@ -52,8 +54,8 @@ def test_chunked_local_attention_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[BlockHashKey(
-                    (block_hash, 0))] = {
+                block_pool.cached_block_hash_to_block[make_block_hash_with_group_id(
+                    block_hash, 0)] = {
                         i: block_pool.blocks[i + 10],
                     }
 
@@ -117,8 +119,8 @@ def test_sliding_window_possible_cached_prefix():
         for i, (block_hash,
                 is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
             if is_cached:
-                block_pool.cached_block_hash_to_block[BlockHashKey(
-                    (block_hash, 0))] = {
+                block_pool.cached_block_hash_to_block[make_block_hash_with_group_id(
+                    block_hash, 0)] = {
                         i: block_pool.blocks[i + 10],
                     }
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -213,7 +213,7 @@ class BlockPool:
             # block_hash not found in cached_block_hash_to_block,
             # eviction is not needed
             return False
-        block.reset_block_hash()
+        block.reset_hash()
         blocks_by_id.pop(block.block_id, None)
         if len(blocks_by_id) == 0:
             del self.cached_block_hash_to_block[block_hash_key]
@@ -283,7 +283,7 @@ class BlockPool:
 
         # Remove all hashes from all blocks.
         for block in self.blocks:
-            block.reset_block_hash()
+            block.reset_hash()
 
         logger.info("Successfully reset prefix cache")
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -133,12 +133,12 @@ class BlockPool:
         new_hashes: Optional[list[BlockHash]] = (
             [] if self.enable_kv_cache_events else None)
         for i, blk in enumerate(new_full_blocks):
-            assert blk.block_hash_with_group_id is None
+            assert blk.block_hash is None
             block_hash = new_block_hashes[i]
 
             # Update and added the full block to the cache.
             key = make_block_hash_with_group_id(block_hash, kv_cache_group_id)
-            blk.block_hash_with_group_id = key
+            blk.block_hash = key
             self.cached_block_hash_to_block[key][blk.block_id] = blk
             if new_hashes is not None:
                 new_hashes.append(block_hash)
@@ -148,9 +148,9 @@ class BlockPool:
                 parent_block_hash: Optional[BlockHash] = None
             else:
                 parent_block = blocks[num_cached_blocks - 1]
-                assert parent_block.block_hash_with_group_id is not None
+                assert parent_block.block_hash is not None
                 parent_block_hash, _ = split_block_hash_with_group_id(
-                    parent_block.block_hash_with_group_id)
+                    parent_block.block_hash)
 
             self.kv_event_queue.append(
                 BlockStored(
@@ -204,28 +204,26 @@ class BlockPool:
         Returns:
             True if the block is evicted, False otherwise.
         """
-        block_hash_with_group_id = block.block_hash_with_group_id
-        if block_hash_with_group_id is None:
+        block_hash_key = block.block_hash
+        if block_hash_key is None:
             # The block doesn't have hash, eviction is not needed
             return False
-        blocks_by_id = self.cached_block_hash_to_block.get(
-            block_hash_with_group_id)
+        blocks_by_id = self.cached_block_hash_to_block.get(block_hash_key)
         if blocks_by_id is None:
             # block_hash not found in cached_block_hash_to_block,
             # eviction is not needed
             return False
-        block.reset_block_hash_with_group_id()
+        block.reset_block_hash()
         blocks_by_id.pop(block.block_id, None)
         if len(blocks_by_id) == 0:
-            del self.cached_block_hash_to_block[block_hash_with_group_id]
+            del self.cached_block_hash_to_block[block_hash_key]
 
         if self.enable_kv_cache_events:
             # FIXME (Chen): Not sure whether we should return `hash_value`
             # or `(hash_value, group_id)` here. But it's fine now because
             # we disable hybrid kv cache manager when kv cache event is
             # enabled, so there is only one group.
-            block_hash, _ = split_block_hash_with_group_id(
-                block_hash_with_group_id)
+            block_hash, _ = split_block_hash_with_group_id(block_hash_key)
             self.kv_event_queue.append(
                 BlockRemoved(block_hashes=[block_hash]))
         return True
@@ -285,7 +283,7 @@ class BlockPool:
 
         # Remove all hashes from all blocks.
         for block in self.blocks:
-            block.reset_block_hash_with_group_id()
+            block.reset_block_hash()
 
         logger.info("Successfully reset prefix cache")
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -72,7 +72,7 @@ class KVCacheBlocks:
         assert len(self.blocks) == 1, "Only one group is supported"
         return [
             block.block_id for block in self.blocks[0]
-            if block.block_hash_with_group_id is None
+            if block.block_hash is None
         ]
 
     def new_empty(self) -> "KVCacheBlocks":

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -72,7 +72,7 @@ class KVCacheBlocks:
         assert len(self.blocks) == 1, "Only one group is supported"
         return [
             block.block_id for block in self.blocks[0]
-            if block.block_hash_key is None
+            if block.block_hash_with_group_id is None
         ]
 
     def new_empty(self) -> "KVCacheBlocks":

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -147,7 +147,7 @@ class KVCacheBlock:
     ref_cnt: int = 0
     # The hash key (block hash + group id) of the block, only available
     # when the block is full and cached.
-    _block_hash_with_group_id: Optional[BlockHashWithGroupId] = None
+    _block_hash: Optional[BlockHashWithGroupId] = None
 
     # Used to construct a doubly linked list for free blocks.
     # These two attributes should only be manipulated by FreeKVCacheBlockQueue.
@@ -158,20 +158,19 @@ class KVCacheBlock:
     is_null: bool = False
 
     @property
-    def block_hash_with_group_id(self) -> Optional[BlockHashWithGroupId]:
-        return self._block_hash_with_group_id
+    def block_hash(self) -> Optional[BlockHashWithGroupId]:
+        return self._block_hash
 
-    @block_hash_with_group_id.setter
-    def block_hash_with_group_id(self,
-                                 block_hash_with_group_id: BlockHashWithGroupId):
-        assert self.block_hash_with_group_id is None, (
-            "block_hash_with_group_id can only be set once to prevent "
+    @block_hash.setter
+    def block_hash(self, block_hash: BlockHashWithGroupId):
+        assert self.block_hash is None, (
+            "block_hash can only be set once to prevent "
             "unintended overrides.")
-        self._block_hash_with_group_id = block_hash_with_group_id
+        self._block_hash = block_hash
 
-    def reset_block_hash_with_group_id(self):
+    def reset_block_hash(self):
         """Reset the block hash when the block is evicted."""
-        self._block_hash_with_group_id = None
+        self._block_hash = None
 
     def __repr__(self) -> str:
         # Use block_id instead of KVCacheBlock object to avoid calling __repr__
@@ -182,7 +181,7 @@ class KVCacheBlock:
                          if self.next_free_block else None)
         return (f"KVCacheBlock(block_id={self.block_id}, "
                 f"ref_cnt={self.ref_cnt}, "
-                f"_block_hash_with_group_id={self._block_hash_with_group_id!r}, "
+                f"_block_hash={self._block_hash!r}, "
                 f"prev_free_block={prev_block_id}, "
                 f"next_free_block={next_block_id})")
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -168,7 +168,7 @@ class KVCacheBlock:
             "unintended overrides.")
         self._block_hash = block_hash
 
-    def reset_block_hash(self):
+    def reset_hash(self):
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
 


### PR DESCRIPTION
## Summary
- rename byte-based BlockHashKey type to BlockHashWithGroupId with pack/unpack helpers
- update block pool, docs, and tests to use BlockHashWithGroupId and new helper names
- rename KVCacheBlock attributes and reset method to block_hash_with_group_id

## Testing
- `python -m pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68adffc6b6c4832abc26c49090a5d4a9